### PR TITLE
fix: increase effector frame precision

### DIFF
--- a/models/nextagea_description/urdf/NextageaOpen.urdf
+++ b/models/nextagea_description/urdf/NextageaOpen.urdf
@@ -715,7 +715,7 @@
 
 	<!-- Effector frames -->
 	<joint name="LARM_EFF" type="fixed">
-	  <origin xyz="0.08 0.05 -0.02" rpy="0 0 1.5"/>
+	  <origin xyz="0.082 0.05 -0.02" rpy="0 0 1.5708"/>
 	  <parent link="LARM_JOINT5_Link"/>
 	  <child link="LARM_EFF_Link"/>
 	</joint>
@@ -724,7 +724,7 @@
   <link name="RARM_EFF_Link">
   </link>
 	<joint name="RARM_EFF" type="fixed">
-	  <origin xyz="0.08 -0.05 -0.02" rpy="0 0 1.5"/>
+	  <origin xyz="0.082 -0.05 -0.02" rpy="0 0 1.5708"/>
 	  <parent link="RARM_JOINT5_Link"/>
 	  <child link="RARM_EFF_Link"/>
 	</joint>


### PR DESCRIPTION
The current end effector frames are represented in the URDF files using [X, Y, Z, roll, pitch and yaw]. Currently yaw is set to 1.5 radians, about 86 degrees. I have increased the precision to 1.5708 to have a better alignment to the box.
Furthermore, I have increase the X values so the end effector frame is not inside the collision model